### PR TITLE
Add per-ERD MQTT publish throttling

### DIFF
--- a/include/HomeAssistantBridge.h
+++ b/include/HomeAssistantBridge.h
@@ -23,7 +23,7 @@ class HomeAssistantBridge {
  public:
   static constexpr unsigned long baud = 230400;
 
-  void begin(PubSubClient& client, Stream& uart, const char* deviceId, uint8_t clientAddress = 0xE4);
+  void begin(PubSubClient& client, Stream& uart, const char* deviceId, uint8_t clientAddress = 0xE4, unsigned long throttleMs = 0);
   void loop();
   void notifyMqttDisconnected();
 

--- a/include/mqtt_client_adapter.hpp
+++ b/include/mqtt_client_adapter.hpp
@@ -24,12 +24,14 @@ typedef struct {
   const char* device_id;
   tiny_event_t write_request;
   tiny_event_t mqtt_disconnect;
+  std::map<uint16_t, unsigned long> last_publish_times;
+  unsigned long throttle_ms;
 } mqtt_client_adapter_t;
 
 /*!
  * Initialize an adapter to expose an Arduino PubSubClient as an i_mqtt_client_t.
  */
-void mqtt_client_adapter_init(mqtt_client_adapter_t* self, PubSubClient* client, const char* deviceId);
+void mqtt_client_adapter_init(mqtt_client_adapter_t* self, PubSubClient* client, const char* deviceId, unsigned long throttle_ms = 0);
 
 /*!
  * Notify the adapter that the MQTT client has connected. Should be called before reconnecting when connection is lost.

--- a/src/HomeAssistantBridge.cpp
+++ b/src/HomeAssistantBridge.cpp
@@ -14,7 +14,7 @@ static const tiny_gea3_erd_client_configuration_t client_configuration = {
   .request_retries = 10
 };
 
-void HomeAssistantBridge::begin(PubSubClient& pubSubClient, Stream& uart, const char* deviceId, uint8_t clientAddress)
+void HomeAssistantBridge::begin(PubSubClient& pubSubClient, Stream& uart, const char* deviceId, uint8_t clientAddress, unsigned long throttleMs)
 {
   this->pubSubClient = &pubSubClient;
 
@@ -22,7 +22,7 @@ void HomeAssistantBridge::begin(PubSubClient& pubSubClient, Stream& uart, const 
 
   tiny_uart_adapter_init(&uart_adapter, &timer_group, uart);
 
-  mqtt_client_adapter_init(&client_adapter, &pubSubClient, deviceId);
+  mqtt_client_adapter_init(&client_adapter, &pubSubClient, deviceId, throttleMs);
 
   uptime_monitor_init(
     &uptime_monitor,

--- a/src/mqtt_client_adapter.cpp
+++ b/src/mqtt_client_adapter.cpp
@@ -3,6 +3,7 @@
  * @brief
  */
 
+#include <Arduino.h>
 #include "mqtt_client_adapter.hpp"
 
 static uint8_t ascii_hex_to_nybble(char ascii_hex)
@@ -67,6 +68,15 @@ static void register_erd(i_mqtt_client_t* _self, tiny_erd_t erd)
 static void update_erd(i_mqtt_client_t* _self, tiny_erd_t erd, const void* _value, uint8_t size)
 {
   auto self = reinterpret_cast<mqtt_client_adapter_t*>(_self);
+
+  if(self->throttle_ms > 0) {
+    auto now = millis();
+    auto it = self->last_publish_times.find(erd);
+    if(it != self->last_publish_times.end() && (now - it->second) < self->throttle_ms) {
+      return;
+    }
+    self->last_publish_times[erd] = now;
+  }
 
   auto payload = String();
   auto bytes = reinterpret_cast<const uint8_t*>(_value);
@@ -151,11 +161,12 @@ static const i_mqtt_client_api_t api = {
   on_mqtt_disconnect
 };
 
-void mqtt_client_adapter_init(mqtt_client_adapter_t* self, PubSubClient* client, const char* deviceId)
+void mqtt_client_adapter_init(mqtt_client_adapter_t* self, PubSubClient* client, const char* deviceId, unsigned long throttle_ms)
 {
   self->interface.api = &api;
   self->client = client;
   self->device_id = deviceId;
+  self->throttle_ms = throttle_ms;
 
   mqtt_callback_self = self;
   client->setCallback(mqtt_callback);


### PR DESCRIPTION
Prevent flooding Home Assistant with frequent sensor updates by throttling MQTT publishes per ERD. Configurable via throttleMs parameter on begin() (default 0 = disabled for backward compatibility).